### PR TITLE
DCB vars syntax correction

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
---
+---
 # vars file for Dell-Networking.dellos-dcb


### PR DESCRIPTION
Fix for Error- The vars/main.yml file for role 'Dell-Networking.dellos-dcb' must contain a dictionary of variables